### PR TITLE
fix: Ensure output ends in new line

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,6 @@ func main() {
 	}
 
 	if *silent == false {
-		fmt.Printf("File `%s` is valid", *file)
+		fmt.Printf("File `%s` is valid\n", *file)
 	}
 }


### PR DESCRIPTION
This patch adds a newline (`\n`) to our success message.

This prevents funky output bugs like this:

![image](https://user-images.githubusercontent.com/571265/76336327-39c0ab80-62cc-11ea-8626-84607e30a199.png)
